### PR TITLE
Use Libdl.dlext instead of old BinDeps.shlib_ext

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,7 +18,7 @@ provides( Sources,
           SHA="0e290078e31211baa7b5886bcc8ab6bc048b9fc83882532da4a1a45e58e907fd",
           libopus )
 provides( BuildProcess,
-          Autotools(libtarget=".libs/libopus."*BinDeps.shlib_ext, configure_options = ["--libdir=$(BinDeps.libdir(libopus))"]),
+          Autotools(libtarget=".libs/libopus."*Libdl.dlext, configure_options = ["--libdir=$(BinDeps.libdir(libopus))"]),
           libopus )
 
 @compat @BinDeps.install Dict(:libopus => :libopus)


### PR DESCRIPTION
When opening an issue, please ping `@staticfloat`.

He does not receive emails automatically when new issues are created.
Without this ping, your issue may slip through the cracks!
If no response is garnered within a week, feel free to ping again.
